### PR TITLE
Add env var overrides for BridgeConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,6 +650,22 @@ for i in range(0, len(text), batch_size):
 # bridgenlp predict --model ner --file large_document.txt --batch-size 100
 ```
 
+## Environment Variables
+
+BridgeNLP can read configuration overrides from environment variables. These
+values take precedence over those provided in dictionaries or JSON files when
+creating a `BridgeConfig` instance.
+
+- `BRIDGENLP_DEVICE` – Device identifier (e.g. `"cpu"`, `"cuda"` or `0`).
+- `BRIDGENLP_BATCH_SIZE` – Default batch size for adapters and pipelines.
+
+For example:
+
+```bash
+export BRIDGENLP_DEVICE=cuda
+export BRIDGENLP_BATCH_SIZE=8
+```
+
 ## Performance Notes and Limitations
 
 - **Memory usage**: BridgeNLP is designed to minimize memory usage by avoiding deep copies and cleaning up resources.

--- a/bridgenlp/config.py
+++ b/bridgenlp/config.py
@@ -84,6 +84,19 @@ class BridgeConfig:
         # Create instance
         config = cls(**base_config)
         config.params = params
+
+        # Environment variable overrides
+        env_device = os.getenv("BRIDGENLP_DEVICE")
+        env_batch_size = os.getenv("BRIDGENLP_BATCH_SIZE")
+        if env_device is not None:
+            config.device = env_device
+        if env_batch_size is not None:
+            try:
+                config.batch_size = int(env_batch_size)
+            except ValueError:
+                raise ValueError(
+                    f"Invalid batch size in BRIDGENLP_BATCH_SIZE: {env_batch_size}"
+                )
         
         # Validate device
         if isinstance(config.device, str) and config.device not in ["cpu", "cuda", "-1"]:

--- a/bridgenlp/tests/test_config.py
+++ b/bridgenlp/tests/test_config.py
@@ -110,3 +110,30 @@ class TestBridgeConfig:
         """Test error handling for missing files."""
         with pytest.raises(FileNotFoundError):
             BridgeConfig.from_json("/path/to/nonexistent/file.json")
+
+    def test_env_overrides_from_dict(self, monkeypatch):
+        """Environment variables override dictionary values."""
+        monkeypatch.setenv("BRIDGENLP_DEVICE", "cuda")
+        monkeypatch.setenv("BRIDGENLP_BATCH_SIZE", "5")
+        config = BridgeConfig.from_dict({
+            "model_type": "test",
+            "device": "cpu",
+            "batch_size": 1,
+        })
+        assert config.device == "cuda"
+        assert config.batch_size == 5
+
+    def test_env_overrides_from_json(self, monkeypatch, tmp_path):
+        """Environment variables override JSON config values."""
+        cfg = {
+            "model_type": "test",
+            "device": -1,
+            "batch_size": 2,
+        }
+        path = tmp_path / "config.json"
+        path.write_text(json.dumps(cfg))
+        monkeypatch.setenv("BRIDGENLP_DEVICE", "0")
+        monkeypatch.setenv("BRIDGENLP_BATCH_SIZE", "3")
+        config = BridgeConfig.from_json(str(path))
+        assert config.device == 0
+        assert config.batch_size == 3


### PR DESCRIPTION
## Summary
- override BridgeConfig fields with `BRIDGENLP_DEVICE` and `BRIDGENLP_BATCH_SIZE`
- document these environment variables
- test that environment variables override dict and JSON values

## Testing
- `pytest bridgenlp/tests/test_config.py::TestBridgeConfig::test_env_overrides_from_dict -q` *(fails: ModuleNotFoundError: No module named 'spacy')*

------
https://chatgpt.com/codex/tasks/task_e_684b4306e21083288d1507375c4befa7