### PR TITLE
Add memory usage metric

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -14,7 +14,10 @@ from bridgenlp.result import BridgeResult
 
 # Create namespaces
 import bridgenlp.adapters as adapters
-import bridgenlp.pipes as pipes
+try:
+    import bridgenlp.pipes as pipes
+except Exception:
+    pipes = None
 
 __all__ = [
     "adapters",

--- a/bridgenlp/cli.py
+++ b/bridgenlp/cli.py
@@ -338,14 +338,15 @@ def process_stream(bridge: BridgeBase, input_stream: TextIO,
     
     # Print summary statistics
     elapsed_time = time.time() - start_time
-    if processed_count > 0 and show_progress:
-        print(f"Processed {processed_count} texts in {elapsed_time:.4f}s "
-              f"({processed_count / elapsed_time:.2f} texts/sec)" if elapsed_time > 0 else
-              f"Processed {processed_count} texts in {elapsed_time:.4f}s", 
-              file=sys.stderr)
-        
-        # Print metrics if available
-        if hasattr(bridge, 'get_metrics'):
+    if processed_count > 0:
+        if show_progress:
+            print(f"Processed {processed_count} texts in {elapsed_time:.4f}s "
+                  f"({processed_count / elapsed_time:.2f} texts/sec)" if elapsed_time > 0 else
+                  f"Processed {processed_count} texts in {elapsed_time:.4f}s",
+                  file=sys.stderr)
+
+        # Print metrics if requested
+        if bridge.config.collect_metrics and hasattr(bridge, 'get_metrics'):
             metrics = bridge.get_metrics()
             if metrics:
                 print("Performance metrics:", file=sys.stderr)

--- a/tests/test_memory_reporting.py
+++ b/tests/test_memory_reporting.py
@@ -1,0 +1,34 @@
+import pytest
+from unittest.mock import patch
+from bridgenlp.base import BridgeBase
+from bridgenlp.config import BridgeConfig
+from bridgenlp.result import BridgeResult
+
+class DummyAdapter(BridgeBase):
+    def __init__(self):
+        super().__init__(BridgeConfig(collect_metrics=True))
+        self._model = None
+
+    def _load_model(self):
+        self._model = object()
+
+    def from_text(self, text: str) -> BridgeResult:
+        with self._measure_performance():
+            if self._model is None:
+                self._load_model()
+            return BridgeResult(tokens=text.split())
+
+    def from_tokens(self, tokens):
+        return BridgeResult(tokens=tokens)
+
+    def from_spacy(self, doc):
+        return BridgeResult(tokens=[t.text for t in doc]).attach_to_spacy(doc)
+
+
+def test_memory_metric_recorded():
+    adapter = DummyAdapter()
+    with patch('bridgenlp.base.get_model_memory_usage', return_value=12.5) as mem:
+        adapter.from_text("hello world")
+        metrics = adapter.get_metrics()
+        assert metrics['memory_mb'] == 12.5
+        assert mem.called


### PR DESCRIPTION
## Summary
- measure model memory in `BridgeBase._measure_performance`
- show metrics when `--collect-metrics` is enabled in CLI
- handle missing spacy import in top-level package
- test memory metric with a mocked adapter

## Testing
- `PYTHONPATH=. pytest tests/test_memory_reporting.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684b430287608328bfa7286def5f23eb